### PR TITLE
Remove FreeGeoIpProvider

### DIFF
--- a/code/AddressGeocoding.php
+++ b/code/AddressGeocoding.php
@@ -35,7 +35,6 @@ class AddressGeocoding extends DataExtension{
 		$geocoder = new \Geocoder\Geocoder();
 		$adapter  = new \Geocoder\HttpAdapter\CurlHttpAdapter();
 		$chain = new \Geocoder\Provider\ChainProvider(array(
-			new \Geocoder\Provider\FreeGeoIpProvider($adapter),
 			new \Geocoder\Provider\HostIpProvider($adapter),
 			new \Geocoder\Provider\GoogleMapsProvider($adapter)
 		));


### PR DESCRIPTION
Remove FreeGeoIpProvider because their server goes down all the time :( Temporary fix for https://github.com/burnbright/silverstripe-shop-geocoding/issues/3